### PR TITLE
Add unit tests for integrator implementation(s)

### DIFF
--- a/test/dependencies_for_runtests.jl
+++ b/test/dependencies_for_runtests.jl
@@ -6,6 +6,8 @@ using StableRNGs
 using Statistics
 using Test
 
+const SEED = 827628136287
+
 @kwdef struct 𝒩{T, M}
     μ::Vector{T} = [0.0 ; 0.0]
     Σ::M = ScalMat(2, 1.)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ include("dependencies_for_runtests.jl")
 
 @testset "Mici.jl" begin
     include("test_e2e.jl")
+    include("test_integrators.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Mici
 using Test
 
+include("dependencies_for_runtests.jl")
+
 @testset "Mici.jl" begin
     include("test_e2e.jl")
 end

--- a/test/test_e2e.jl
+++ b/test/test_e2e.jl
@@ -1,7 +1,3 @@
-include("dependencies_for_runtests.jl")
-
-using Mici.Mici: EuclideanHMC
-
 @testset "Abstract MCMC e2e" begin
 
     ℓ = 𝒩()

--- a/test/test_e2e.jl
+++ b/test/test_e2e.jl
@@ -2,7 +2,7 @@
 
     ℓ = 𝒩()
     model = LogDensityModel(ℓ)
-    rng = StableRNG(1234)
+    rng = StableRNG(SEED)
     C1 = 2.
     C2 = 5.
 

--- a/test/test_integrators.jl
+++ b/test/test_integrators.jl
@@ -1,0 +1,36 @@
+@testset "Integrator unit tests for dimension $dimension" for dimension in (1, 2, 5, 10)
+    rng = StableRNG(SEED)
+    metric = ScalMat(dimension, 1.)
+    log_density = 𝒩(zeros(dimension), ScalMat(dimension, 1.))
+    system = EuclideanSystem(metric, log_density)
+    phase_point = Mici.sample_initial_phase_point(rng, system, nothing)
+    initial_phase_point = copy(phase_point)
+    ϵ = 0.5
+    integrator = LeapfrogIntegrator(ϵ)
+    Mici.step!(phase_point, integrator, system)
+    # Single step should keep phase point components finite and change values
+    @test all(isfinite.(phase_point.q))
+    @test all(isfinite.(phase_point.p))
+    @test all(phase_point.q != initial_phase_point.q)
+    @test all(phase_point.p != initial_phase_point.p)
+    # Composing step with momentum flips should return us to initial phase point 
+    phase_point.p *= -1
+    Mici.step!(phase_point, integrator, system)
+    phase_point.p *= -1
+    @test all(phase_point.q ≈ initial_phase_point.q)
+    @test all(phase_point.p ≈ initial_phase_point.p)
+    # Stepping with ϵ=0 should not change phase point value
+    phase_point = copy(initial_phase_point)
+    zero_step_integrator = LeapfrogIntegrator(0.)
+    Mici.step!(phase_point, zero_step_integrator, system)
+    @test all(phase_point.q ≈ initial_phase_point.q)
+    @test all(phase_point.p ≈ initial_phase_point.p)
+    # Integrating over multiple steps should approximately conserve Hamiltonian
+    initial_h = Mici.h(initial_phase_point, system)
+    phase_point = copy(initial_phase_point)
+    for _ in 1:100
+        Mici.step!(phase_point, integrator, system)
+    end
+    final_h = Mici.h(phase_point, system)
+    @test abs(final_h - initial_h) < 0.1
+end


### PR DESCRIPTION
Adds some basic unit tests for integrators (currently only `LeapfrogIntegrator` but should be simple to extend to other integrator types) that checks that a few key invariants are maintained by each integrator step:

- that each step keeps all phase point components finite and with a non-zero step size changes all phase point components;
- that the composition of a step, momentum flip, another step, and then another momentum flip is an identity map (so that the integrator is time-reversible);
- that a step with a zero step size $\epsilon$ does not change any of phase point components;
- that integrating over multiple steps the Hamiltonian of the system remains approximately conserved.