### PR TITLE
NUTS without termination criterion

### DIFF
--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -2,8 +2,8 @@ struct LeapfrogIntegrator{T} <: AbstractIntegrator
     ϵ::T
 end
 
-function step!(z::PhasePoint, integrator::LeapfrogIntegrator, system::AbstractTractableFlowSystem; dir=1)
-    Φ₁!(z, system, dir*integrator.ϵ / 2)
-    Φ₂!(z, system, dir*integrator.ϵ)
-    Φ₁!(z, system, dir*integrator.ϵ / 2)
+function step!(z::PhasePoint, integrator::LeapfrogIntegrator, system::AbstractTractableFlowSystem; direction=1)
+    Φ₁!(z, system, direction*integrator.ϵ / 2)
+    Φ₂!(z, system, direction*integrator.ϵ)
+    Φ₁!(z, system, direction*integrator.ϵ / 2)
 end

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -2,9 +2,8 @@ struct LeapfrogIntegrator{T} <: AbstractIntegrator
     ϵ::T
 end
 
-function step!(z::PhasePoint, integrator::LeapfrogIntegrator, system::AbstractTractableFlowSystem)
-    Φ₁!(z, system, integrator.ϵ / 2)
-    Φ₂!(z, system, integrator.ϵ)
-    Φ₁!(z, system, integrator.ϵ / 2)
+function step!(z::PhasePoint, integrator::LeapfrogIntegrator, system::AbstractTractableFlowSystem; dir=1)
+    Φ₁!(z, system, dir*integrator.ϵ / 2)
+    Φ₂!(z, system, dir*integrator.ϵ)
+    Φ₁!(z, system, dir*integrator.ϵ / 2)
 end
-

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -60,5 +60,7 @@ end
 function state_type(
     ::HMC{S,I,TI,TM}
 ) where {S,I,TI<:AbstractNUTSTransition,TM}
+    # TODO: Define a separate state type for NUTS or even a more general
+    # state type with metaprogramming to include fields specific to different transition types.
     MetropolisHMCState
 end

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -45,10 +45,10 @@ function EuclideanHMC(integration_time_lower::Real, integration_time_upper::Real
     EuclideanHMC{LeapfrogIntegrator}(integration_time_lower, integration_time_upper)
 end
 
-const NUTS{S,I,TM} = HMC{S,I,AbstractNUTSTransition,TM}
+const NUTS{S,I,TI<:AbstractNUTSTransition,TM} = HMC{S,I,TI,TM}
 
 function EuclideanNUTS(max_depth::Int)
-    NUTS{EuclideanSystem, LeapfrogIntegrator}(NUTSTransition(max_depth, max_delta_h=1000.0))
+    HMC{EuclideanSystem,LeapfrogIntegrator}(NUTSTransition(max_depth, 1000.0))
 end
 
 function state_type(

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -45,8 +45,20 @@ function EuclideanHMC(integration_time_lower::Real, integration_time_upper::Real
     EuclideanHMC{LeapfrogIntegrator}(integration_time_lower, integration_time_upper)
 end
 
+const NUTS{S,I,TM} = HMC{S,I,AbstractNUTSTransition,TM}
+
+function EuclideanNUTS(max_depth::Int)
+    NUTS{EuclideanSystem, LeapfrogIntegrator}(NUTSTransition(max_depth, max_delta_h=1000.0))
+end
+
 function state_type(
     ::HMC{S,I,TI,TM}
 ) where {S,I,TI<:AbstractMetropolisIntegrationTransition,TM}
+    MetropolisHMCState
+end
+
+function state_type(
+    ::HMC{S,I,TI,TM}
+) where {S,I,TI<:AbstractNUTSTransition,TM}
     MetropolisHMCState
 end

--- a/src/state.jl
+++ b/src/state.jl
@@ -111,10 +111,6 @@ struct MetropolisHMCState{P,S,I} <: AbstractState{P,S,I}
     integrator::I
 end
 
-function get_momentum(state::MetropolisHMCState)
-    return state.phase_point.p
-end
-
 function MetropolisHMCState(
     phase_point::PhasePoint, system::AbstractSystem, integrator::AbstractIntegrator
 )

--- a/src/state.jl
+++ b/src/state.jl
@@ -18,6 +18,10 @@ mutable struct PhasePoint{T}
     valid::Bool
 end
 
+function PhasePoint(q::Vector{T}, p::Vector{T}, dimension::Integer) where {T}
+    PhasePoint{T}(q, p, T(NaN), Vector{T}(undef, dimension), false)
+end
+
 function PhasePoint(::UndefInitializer, dimension::Integer, T::Type=Float64)
     PhasePoint(Vector{T}(undef, dimension), Vector{T}(undef, dimension), T(NaN), Vector{T}(undef, dimension), false)
 end
@@ -94,6 +98,7 @@ Concrete subtypes of `AbstractState` should contain at least the following field
 """
 abstract type AbstractState{P,S,I} end
 
+
 """
     MetropolisHMCState{P, S, I} <: AbstractState{P,S,I}
 
@@ -104,6 +109,10 @@ struct MetropolisHMCState{P,S,I} <: AbstractState{P,S,I}
     proposed_phase_point::P
     system::S
     integrator::I
+end
+
+function get_momentum(state::MetropolisHMCState)
+    return state.phase_point.p
 end
 
 function MetropolisHMCState(

--- a/src/transition.jl
+++ b/src/transition.jl
@@ -157,18 +157,18 @@ function merge_subtrees(
     )
 end
 
-function build_tree(depth::Int, direction::Int, phase_point::PhasePoint, integrator::AbstractIntegrator, system::AbstractSystem)
+function build_tree(rng::AbstractRNG, depth::Int, direction::Int, phase_point::PhasePoint, integrator::AbstractIntegrator, system::AbstractSystem)
     if depth == 0
         new_phase_point = copy(phase_point)
         step!(new_phase_point, integrator, system; direction)
         h_value = h(new_phase_point, system)
 
-        return new_leaf(new_phase_point, h_value)
+        return new_leaf(new_phase_point, h_value), new_phase_point
     end
 
-    inner_tree = build_tree(depth - 1, direction, phase_point, integrator, system)
+    inner_tree, inner_proposal = build_tree(rng, depth - 1, direction, phase_point, integrator, system)
     phase_point = direction == 1 ? inner_tree.right : inner_tree.left
-    outer_tree = build_tree(depth - 1, direction, phase_point, integrator, system)
+    outer_tree, outer_proposal = build_tree(rng, depth - 1, direction, phase_point, integrator, system)
     left_subtree, right_subtree = if direction == 1
         inner_tree, outer_tree
     else
@@ -176,5 +176,37 @@ function build_tree(depth::Int, direction::Int, phase_point::PhasePoint, integra
     end
     tree = merge_subtrees(left_subtree, right_subtree)
 
-    return tree
+    accept_outer_prob = min(outer_tree.weight / tree.weight, 1.0)
+    proposal = rand(rng) < accept_outer_prob ? outer_proposal : inner_proposal
+
+    return tree, proposal
+end
+
+function transition!(state::AbstractState, rng::AbstractRNG, transition::NUTSTransition)
+
+    tree = new_leaf(state.proposed_phase_point, h(state.proposed_phase_point, state.system))
+
+    for depth in 0:transition.max_depth
+
+        direction = rand(rng, Bool) ? 1 : -1
+        if direction == 1
+            copy!(state.proposed_phase_point, tree.right)
+        else
+            copy!(state.proposed_phase_point, tree.left)
+        end
+
+        new_tree, proposal = build_tree(rng, depth, direction, state.proposed_phase_point, state.integrator, state.system)
+
+        accept_prob = min(new_tree.weight / tree.weight, 1.0)
+        if rand(rng) < accept_prob
+            copy!(state.phase_point, proposal)
+        end
+
+        left_subtree = direction == 1 ? tree : new_tree
+        right_subtree = direction == 1 ? new_tree : tree
+        tree = merge_subtrees(left_subtree, right_subtree)
+
+    end
+
+    return nothing
 end

--- a/src/transition.jl
+++ b/src/transition.jl
@@ -184,18 +184,19 @@ end
 
 function transition!(state::AbstractState, rng::AbstractRNG, transition::NUTSTransition)
 
-    tree = new_leaf(state.proposed_phase_point, h(state.proposed_phase_point, state.system))
+    tree = new_leaf(copy(state.phase_point), h(state.phase_point, state.system))
+    next_phase_point = copy(state.phase_point)
 
-    for depth in 0:transition.max_depth
+    for depth in 0:(transition.max_depth - 1)
 
         direction = rand(rng, Bool) ? 1 : -1
         if direction == 1
-            copy!(state.proposed_phase_point, tree.right)
+            copy!(next_phase_point, tree.right)
         else
-            copy!(state.proposed_phase_point, tree.left)
+            copy!(next_phase_point, tree.left)
         end
 
-        new_tree, proposal = build_tree(rng, depth, direction, state.proposed_phase_point, state.integrator, state.system)
+        new_tree, proposal = build_tree(rng, depth, direction, next_phase_point, state.integrator, state.system)
 
         accept_prob = min(new_tree.weight / tree.weight, 1.0)
         if rand(rng) < accept_prob
@@ -208,5 +209,5 @@ function transition!(state::AbstractState, rng::AbstractRNG, transition::NUTSTra
 
     end
 
-    return nothing
+    return (; )
 end

--- a/src/transition.jl
+++ b/src/transition.jl
@@ -151,25 +151,30 @@ function merge_subtrees(
     return SubTree(
         left.left,
         right.right,
-        left.momentum + pos.momentum,
-        left.weight + pos.weight,
+        left.momentum + right.momentum,
+        left.weight + right.weight,
         left.depth + 1,
     )
 end
 
-function build_tree(depth::Int, phase_point::PhasePoint, integrator::AbstractIntegrator, system::AbstractSystem)
+function build_tree(depth::Int, direction::Int, phase_point::PhasePoint, integrator::AbstractIntegrator, system::AbstractSystem)
     if depth == 0
         new_phase_point = copy(phase_point)
-        step!(new_phase_point, integrator, system)
+        step!(new_phase_point, integrator, system; direction)
         h_value = h(new_phase_point, system)
 
         return new_leaf(new_phase_point, h_value)
     end
 
-    inner_tree = build_tree(depth - 1, phase_point, integrator, system)
+    inner_tree = build_tree(depth - 1, direction, phase_point, integrator, system)
+    phase_point = direction == 1 ? inner_tree.right : inner_tree.left
+    outer_tree = build_tree(depth - 1, direction, phase_point, integrator, system)
+    left_subtree, right_subtree = if direction == 1
+        inner_tree, outer_tree
+    else
+        outer_tree, inner_tree
+    end
+    tree = merge_subtrees(left_subtree, right_subtree)
 
-    
-
-
-
+    return tree
 end

--- a/src/transition.jl
+++ b/src/transition.jl
@@ -23,6 +23,11 @@ Abstract supertype for Metropolis-adjusted integration transitions in MCMC sampl
 abstract type AbstractMetropolisIntegrationTransition{T} <: AbstractIntegrationTransition end
 
 """
+    AbstractNUTSTransition{T} <: AbstractIntegrationTransition
+"""
+abstract type AbstractNUTSTransition <: AbstractIntegrationTransition end
+
+"""
     AbstractMomentumTransition <: AbstractTransition
 
 Abstract supertype for momentum transitions in MCMC samplers. 
@@ -115,3 +120,56 @@ function transition!(
     return nothing
 end
 
+
+struct SubTree{C, T, W}
+    left::C
+    right::C
+    momentum::T
+    weight::W
+    depth::Int
+end
+
+struct NUTSTransition{T} <: AbstractNUTSTransition
+    max_depth::Int
+    max_delta_h::T
+end
+
+function new_leaf(
+    phase_point::PhasePoint,
+    h,
+)
+    # ToDo numerical stabilisation, logsumexp
+    return SubTree(phase_point, phase_point, phase_point.p, exp(-h), 0)
+end
+
+function merge_subtrees(
+    left::SubTree,
+    right::SubTree,
+)
+    left.depth == right.depth || error("Cannot merge subtrees of different depths.")
+
+    return SubTree(
+        left.left,
+        right.right,
+        left.momentum + pos.momentum,
+        left.weight + pos.weight,
+        left.depth + 1,
+    )
+end
+
+function build_tree(depth::Int, phase_point::PhasePoint, integrator::AbstractIntegrator, system::AbstractSystem)
+    if depth == 0
+        new_phase_point = copy(phase_point)
+        step!(new_phase_point, integrator, system)
+        h_value = h(new_phase_point, system)
+
+        return new_leaf(new_phase_point, h_value)
+    end
+
+    inner_tree = build_tree(depth - 1, phase_point, integrator, system)
+
+    
+
+
+
+end

--- a/src/transition.jl
+++ b/src/transition.jl
@@ -198,6 +198,7 @@ function transition!(state::AbstractState, rng::AbstractRNG, transition::NUTSTra
 
         new_tree, proposal = build_tree(rng, depth, direction, next_phase_point, state.integrator, state.system)
 
+        # bias proposals towards new subtrees to encourage exploration of the state space
         accept_prob = min(new_tree.weight / tree.weight, 1.0)
         if rand(rng) < accept_prob
             copy!(state.phase_point, proposal)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Mici
 using Test
 
 @testset "Mici.jl" begin
+    include("test_sample.jl")
     include("test_transition.jl")
     include("test_e2e.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using Test
 
 @testset "Mici.jl" begin
     include("test_transition.jl")
+    include("test_e2e.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,5 @@ using Mici
 using Test
 
 @testset "Mici.jl" begin
-    include("test_e2e.jl")
+    include("test_transition.jl")
 end

--- a/test/test_e2e.jl
+++ b/test/test_e2e.jl
@@ -1,16 +1,14 @@
 include("dependencies_for_runtests.jl")
 
-using Mici.Mici: EuclideanHMC
+using Mici.Mici: EuclideanHMC, EuclideanNUTS
 
-@testset "Abstract MCMC e2e" begin
+@testset "Abstract MCMC e2e for sampler $sampler" for sampler in (EuclideanHMC(1.5, 3.0), EuclideanNUTS(7))
 
     ℓ = 𝒩()
     model = LogDensityModel(ℓ)
     rng = StableRNG(1234)
     C1 = 2.
     C2 = 5.
-
-    sampler = EuclideanHMC(1.5, 3.0)
 
     initial_q = randn(rng, 2)
 
@@ -20,4 +18,5 @@ using Mici.Mici: EuclideanHMC
         @test norm(mean(q, dims=2) - ℓ.μ) < C1 / sqrt(n_samples)
         @test norm(cov(q, dims=2) - ℓ.Σ) < C2 / sqrt(n_samples)
     end
+
 end

--- a/test/test_e2e.jl
+++ b/test/test_e2e.jl
@@ -2,7 +2,7 @@ include("dependencies_for_runtests.jl")
 
 using Mici.Mici: EuclideanHMC, EuclideanNUTS
 
-@testset "Abstract MCMC e2e for sampler $sampler" for sampler in (EuclideanHMC(1.5, 3.0), EuclideanNUTS(7))
+@testset "Abstract MCMC e2e for sampler $(sampler.integration_transition)" for sampler in (EuclideanHMC(1.5, 3.0), EuclideanNUTS(7))
 
     ℓ = 𝒩()
     model = LogDensityModel(ℓ)

--- a/test/test_sample.jl
+++ b/test/test_sample.jl
@@ -1,0 +1,12 @@
+include("dependencies_for_runtests.jl")
+
+using Mici.Mici:
+    EuclideanHMC,
+    EuclideanNUTS,
+    MetropolisHMCState,
+    state_type
+
+@testset "state_type" begin
+    @test state_type(EuclideanHMC(1.0)) === MetropolisHMCState
+    @test state_type(EuclideanNUTS(7)) === MetropolisHMCState
+end

--- a/test/test_transition.jl
+++ b/test/test_transition.jl
@@ -1,27 +1,41 @@
 include("dependencies_for_runtests.jl")
 
 using Mici.Mici: MetropolisHMCState, PhasePoint, EuclideanSystem, LeapfrogIntegrator
-using Mici.Mici: new_leaf, merge_subtrees
+using Mici.Mici: new_leaf, merge_subtrees, build_tree
 
-@testset "NUTS" begin
+@testset "NUTS for depth $depth" for depth in (1, 2, 5, 10)
     ℓ = 𝒩()
     q = [1.0, 1.0]
     p = [1.0, 1.0]
-    z = PhasePoint(q, p, 2)
+    phase_point = PhasePoint(q, p, 2)
     M = PDMat([1.0 0.5; 0.5 1.0])
     system = EuclideanSystem(M, ℓ)
     integrator = LeapfrogIntegrator(0.1)
 
-    state = MetropolisHMCState(
-        z,
-        system,
-        integrator
-    )
+    direction = 1
+    tree = build_tree(depth, direction, phase_point, integrator, system)
 
-    subtree_1 = new_leaf(state)
+    Mici.step!(phase_point, integrator, system; direction)
 
-    subtree_2 = new_leaf(state)
+    @test tree.depth == depth
+    if direction == 1
+        @test all(tree.left.q == phase_point.q)
+        @test all(tree.left.p == phase_point.p)
+    else
+        @test all(tree.right.q == phase_point.q)
+        @test all(tree.right.p == phase_point.p)
+    end
 
-    merge_subtrees(subtree_1, subtree_2)
+    for _ in 1:(2^depth - 1)
+        Mici.step!(phase_point, integrator, system; direction)
+    end
+
+    if direction == 1
+        @test all(tree.right.q ≈ phase_point.q)
+        @test all(tree.right.p ≈ phase_point.p)
+    else
+        @test all(tree.left.q ≈ phase_point.q)
+        @test all(tree.left.p ≈ phase_point.p)
+    end
 
 end

--- a/test/test_transition.jl
+++ b/test/test_transition.jl
@@ -1,0 +1,27 @@
+include("dependencies_for_runtests.jl")
+
+using Mici.Mici: MetropolisHMCState, PhasePoint, EuclideanSystem, LeapfrogIntegrator
+using Mici.Mici: new_leaf, merge_subtrees
+
+@testset "NUTS" begin
+    ℓ = 𝒩()
+    q = [1.0, 1.0]
+    p = [1.0, 1.0]
+    z = PhasePoint(q, p, 2)
+    M = PDMat([1.0 0.5; 0.5 1.0])
+    system = EuclideanSystem(M, ℓ)
+    integrator = LeapfrogIntegrator(0.1)
+
+    state = MetropolisHMCState(
+        z,
+        system,
+        integrator
+    )
+
+    subtree_1 = new_leaf(state)
+
+    subtree_2 = new_leaf(state)
+
+    merge_subtrees(subtree_1, subtree_2)
+
+end

--- a/test/test_transition.jl
+++ b/test/test_transition.jl
@@ -52,12 +52,7 @@ end
     integrator = LeapfrogIntegrator(0.1)
     state = MetropolisHMCState(phase_point, system, integrator)
 
-    display(state.phase_point.q)
-
     transition = NUTSTransition(4, 10)
-
     transition!(state, rng, transition)
-
-    display(state.phase_point.q)
 
 end

--- a/test/test_transition.jl
+++ b/test/test_transition.jl
@@ -1,10 +1,11 @@
 include("dependencies_for_runtests.jl")
 
-using Mici.Mici: MetropolisHMCState, PhasePoint, EuclideanSystem, LeapfrogIntegrator
-using Mici.Mici: new_leaf, merge_subtrees, build_tree
+using Mici.Mici: MetropolisHMCState, PhasePoint, EuclideanSystem, LeapfrogIntegrator, NUTSTransition
+using Mici.Mici: new_leaf, merge_subtrees, build_tree, transition!
 
-@testset "NUTS for depth $depth" for depth in (1, 2, 5, 10)
+@testset "NUTS build_tree for depth $depth" for depth in (1, 2, 5, 10)
     ℓ = 𝒩()
+    rng = StableRNG(1234)
     q = [1.0, 1.0]
     p = [1.0, 1.0]
     phase_point = PhasePoint(q, p, 2)
@@ -13,7 +14,7 @@ using Mici.Mici: new_leaf, merge_subtrees, build_tree
     integrator = LeapfrogIntegrator(0.1)
 
     direction = 1
-    tree = build_tree(depth, direction, phase_point, integrator, system)
+    tree, _ = build_tree(rng, depth, direction, phase_point, integrator, system)
 
     Mici.step!(phase_point, integrator, system; direction)
 
@@ -37,5 +38,26 @@ using Mici.Mici: new_leaf, merge_subtrees, build_tree
         @test all(tree.left.q ≈ phase_point.q)
         @test all(tree.left.p ≈ phase_point.p)
     end
+
+end
+
+@testset "NUTS transition" begin
+    ℓ = 𝒩()
+    q = [1.0, 1.0]
+    p = [1.0, 1.0]
+    rng = StableRNG(1234)
+    phase_point = PhasePoint(q, p, 2)
+    M = PDMat([1.0 0.5; 0.5 1.5])
+    system = EuclideanSystem(M, ℓ)
+    integrator = LeapfrogIntegrator(0.1)
+    state = MetropolisHMCState(phase_point, system, integrator)
+
+    display(state.phase_point.q)
+
+    transition = NUTSTransition(4, 10)
+
+    transition!(state, rng, transition)
+
+    display(state.phase_point.q)
 
 end

--- a/test/test_transition.jl
+++ b/test/test_transition.jl
@@ -1,7 +1,7 @@
 include("dependencies_for_runtests.jl")
 
 using Mici.Mici: MetropolisHMCState, PhasePoint, EuclideanSystem, LeapfrogIntegrator, NUTSTransition
-using Mici.Mici: new_leaf, merge_subtrees, build_tree, transition!
+using Mici.Mici: new_leaf, merge_subtrees, build_tree, transition!, state_type
 
 @testset "NUTS build_tree for depth $depth" for depth in (1, 2, 5, 10)
     ℓ = 𝒩()
@@ -40,6 +40,7 @@ using Mici.Mici: new_leaf, merge_subtrees, build_tree, transition!
     end
 
 end
+
 
 @testset "NUTS transition" begin
     ℓ = 𝒩()


### PR DESCRIPTION
Initial implementation of NUTS but without more complex features (e.g. termination criterion).
- Adds ability to build a binary tree with a single fixed depth.
- Build and merge multiple binary trees of varying depth
- `transition!` implementation with Multinomial Sampling
- Modifies `step!` implementation to allow forward or backward in time steps